### PR TITLE
fix: prune stale asset references inside replicator/grid/bard sets

### DIFF
--- a/src/AssetScanner.php
+++ b/src/AssetScanner.php
@@ -5,6 +5,7 @@ namespace VV\AssetAtlas;
 use Illuminate\Support\Arr;
 use Statamic\Data\DataReferenceUpdater;
 use Statamic\Facades\AssetContainer;
+use Statamic\Fields\Fields;
 use VV\AssetAtlas\Concerns\GetsItemMetaData;
 
 class AssetScanner extends DataReferenceUpdater
@@ -110,6 +111,49 @@ class AssetScanner extends DataReferenceUpdater
             ->scanBardFieldValues($fields, $dottedPrefix)
             ->scanMarkdownFieldValues($fields, $dottedPrefix)
             ->updateNestedFieldValues($fields, $dottedPrefix);
+    }
+
+    /*
+     * The nested-children traversal inherited from DataReferenceUpdater reads the
+     * set/row structure straight from the live item ($this->item->data()). The
+     * scanner instead has to honour $this->dataToScan, because when we re-scan the
+     * *original* data to prune stale references we pass that snapshot in as the
+     * source. Without these overrides the original pass would iterate the *current*
+     * set structure, never visit sets that were removed, and leave their asset
+     * references orphaned in the atlas. Each override mirrors its parent verbatim
+     * except for the data source.
+     */
+    protected function updateReplicatorChildren($field, $dottedKey)
+    {
+        collect(Arr::get($this->dataToScan, $dottedKey))->each(function ($set, $setKey) use ($dottedKey, $field) {
+            $setHandle = Arr::get($set, 'type');
+            $fields = Arr::get($field->fieldtype()->flattenedSetsConfig(), "{$setHandle}.fields");
+
+            if ($setHandle && $fields) {
+                $this->recursivelyUpdateFields((new Fields($fields))->all(), "{$dottedKey}.{$setKey}.");
+            }
+        });
+    }
+
+    protected function updateGridChildren($field, $dottedKey)
+    {
+        collect(Arr::get($this->dataToScan, $dottedKey))->each(function ($set, $setKey) use ($dottedKey, $field) {
+            if ($fields = Arr::get($field->config(), 'fields')) {
+                $this->recursivelyUpdateFields((new Fields($fields))->all(), "{$dottedKey}.{$setKey}.");
+            }
+        });
+    }
+
+    protected function updateBardChildren($field, $dottedKey)
+    {
+        collect(Arr::get($this->dataToScan, $dottedKey))->each(function ($set, $setKey) use ($dottedKey, $field) {
+            $setHandle = Arr::get($set, 'attrs.values.type');
+            $fields = Arr::get($field->fieldtype()->flattenedSetsConfig(), "{$setHandle}.fields");
+
+            if ($setHandle && $fields) {
+                $this->recursivelyUpdateFields((new Fields($fields))->all(), "{$dottedKey}.{$setKey}.attrs.values.");
+            }
+        });
     }
 
     protected function getConfiguredAssetsFieldContainer($field)

--- a/src/AssetScanner.php
+++ b/src/AssetScanner.php
@@ -5,7 +5,6 @@ namespace VV\AssetAtlas;
 use Illuminate\Support\Arr;
 use Statamic\Data\DataReferenceUpdater;
 use Statamic\Facades\AssetContainer;
-use Statamic\Fields\Fields;
 use VV\AssetAtlas\Concerns\GetsItemMetaData;
 
 class AssetScanner extends DataReferenceUpdater
@@ -93,7 +92,24 @@ class AssetScanner extends DataReferenceUpdater
     {
         $this->atlasItems = collect([]);
         $this->dataToScan = $source ?? $this->item->data()->all();
-        $this->recursivelyUpdateFields($this->getTopLevelFields());
+
+        // The nested-children traversal inherited from DataReferenceUpdater reads
+        // the set/row structure straight from $this->item->data(), not from the
+        // snapshot in $this->dataToScan. So that the inherited replicator/grid/
+        // bard/group traversals visit the same sets the leaf scanners do - in
+        // particular the *original* data when pruning stale references - align the
+        // item's data with the snapshot for the duration of the scan, then restore.
+        // data() is a pure property setter (ContainsData) and the scan path never
+        // saves the item, so this swap has no persistence side effects.
+        $previousData = $this->item->data()->all();
+
+        $this->item->data($this->dataToScan);
+
+        try {
+            $this->recursivelyUpdateFields($this->getTopLevelFields());
+        } finally {
+            $this->item->data($previousData);
+        }
     }
 
     protected function push(string $container, string $path)
@@ -111,49 +127,6 @@ class AssetScanner extends DataReferenceUpdater
             ->scanBardFieldValues($fields, $dottedPrefix)
             ->scanMarkdownFieldValues($fields, $dottedPrefix)
             ->updateNestedFieldValues($fields, $dottedPrefix);
-    }
-
-    /*
-     * The nested-children traversal inherited from DataReferenceUpdater reads the
-     * set/row structure straight from the live item ($this->item->data()). The
-     * scanner instead has to honour $this->dataToScan, because when we re-scan the
-     * *original* data to prune stale references we pass that snapshot in as the
-     * source. Without these overrides the original pass would iterate the *current*
-     * set structure, never visit sets that were removed, and leave their asset
-     * references orphaned in the atlas. Each override mirrors its parent verbatim
-     * except for the data source.
-     */
-    protected function updateReplicatorChildren($field, $dottedKey)
-    {
-        collect(Arr::get($this->dataToScan, $dottedKey))->each(function ($set, $setKey) use ($dottedKey, $field) {
-            $setHandle = Arr::get($set, 'type');
-            $fields = Arr::get($field->fieldtype()->flattenedSetsConfig(), "{$setHandle}.fields");
-
-            if ($setHandle && $fields) {
-                $this->recursivelyUpdateFields((new Fields($fields))->all(), "{$dottedKey}.{$setKey}.");
-            }
-        });
-    }
-
-    protected function updateGridChildren($field, $dottedKey)
-    {
-        collect(Arr::get($this->dataToScan, $dottedKey))->each(function ($set, $setKey) use ($dottedKey, $field) {
-            if ($fields = Arr::get($field->config(), 'fields')) {
-                $this->recursivelyUpdateFields((new Fields($fields))->all(), "{$dottedKey}.{$setKey}.");
-            }
-        });
-    }
-
-    protected function updateBardChildren($field, $dottedKey)
-    {
-        collect(Arr::get($this->dataToScan, $dottedKey))->each(function ($set, $setKey) use ($dottedKey, $field) {
-            $setHandle = Arr::get($set, 'attrs.values.type');
-            $fields = Arr::get($field->fieldtype()->flattenedSetsConfig(), "{$setHandle}.fields");
-
-            if ($setHandle && $fields) {
-                $this->recursivelyUpdateFields((new Fields($fields))->all(), "{$dottedKey}.{$setKey}.attrs.values.");
-            }
-        });
     }
 
     protected function getConfiguredAssetsFieldContainer($field)

--- a/src/Overrides/UpdateAssetReferences.php
+++ b/src/Overrides/UpdateAssetReferences.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VV\AssetAtlas\Subscribers;
+namespace VV\AssetAtlas\Overrides;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
@@ -9,6 +9,7 @@ use Statamic\Events\AssetReplaced;
 use Statamic\Events\AssetSaved;
 use Statamic\Listeners\UpdateAssetReferences as BaseListener;
 use VV\AssetAtlas\AssetAtlas;
+use VV\AssetAtlas\Subscribers\TrackAssetReferences;
 
 class UpdateAssetReferences extends BaseListener
 {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -5,12 +5,15 @@ namespace VV\AssetAtlas;
 use Statamic\Listeners\UpdateAssetReferences as StatamicUpdateAssetReferences;
 use Statamic\Providers\AddonServiceProvider;
 use VV\AssetAtlas\Commands\Scan;
-use VV\AssetAtlas\Subscribers\UpdateAssetReferences;
+use VV\AssetAtlas\Overrides\UpdateAssetReferences;
 
 class ServiceProvider extends AddonServiceProvider
 {
     public function register()
     {
+        // Replace Statamic's UpdateAssetReferences listener with our atlas-backed
+        // subclass. Kept out of src/Subscribers and src/Listeners (both auto-discovered
+        // by the addon) so it's registered once here, not a second time by discovery.
         $this->app->bind(StatamicUpdateAssetReferences::class, UpdateAssetReferences::class);
 
         $this->app->singleton(Atlas::class, function () {

--- a/src/Subscribers/TrackAssetReferences.php
+++ b/src/Subscribers/TrackAssetReferences.php
@@ -74,10 +74,13 @@ class TrackAssetReferences extends Subscriber
     {
         $id = $event->variables->id();
 
-        Blink::put(
-            'assetatlas-globalvar-'.$id,
-            GlobalVariables::find($id)->data()->all()
-        );
+        // No persisted version yet (e.g. a brand-new global set) means there is
+        // no original data to diff against, so there is nothing to stash.
+        if (! $existing = GlobalVariables::find($id)) {
+            return;
+        }
+
+        Blink::put('assetatlas-globalvar-'.$id, $existing->data()->all());
     }
 
     public function handleTermDeleted(TermDeleted $event)

--- a/tests/Concerns/CreatesTestEntries.php
+++ b/tests/Concerns/CreatesTestEntries.php
@@ -114,6 +114,93 @@ trait CreatesTestEntries
     }
 
     /**
+     * Create an entry with asset data in multiple replicator sets.
+     * Each element of \$setsData becomes one replicator set of type `new_set`,
+     * keyed by an `id`, carrying the given field => data pairs.
+     *
+     * @param  array<int, array<string, mixed>>  $setsData
+     */
+    protected function createEntryWithReplicatorSets(array $setsData): Entry
+    {
+        $replicatorData = array_map(function (array $fieldData) {
+            return [
+                'id' => uniqid(),
+                'type' => 'new_set',
+                'enabled' => true,
+            ] + $fieldData;
+        }, $setsData);
+
+        $entry = EntryFacade::make()
+            ->collection('pages')
+            ->blueprint('page')
+            ->slug('test-page-replicator-multi-'.time().'-'.uniqid())
+            ->data([
+                'title' => 'Test Page with Multiple Replicator Sets',
+                'replicator_field' => $replicatorData,
+            ]);
+
+        $entry->save();
+
+        return $entry;
+    }
+
+    /**
+     * Create an entry with asset data in multiple grid rows.
+     *
+     * @param  array<int, array<string, mixed>>  $rowsData
+     */
+    protected function createEntryWithGridRows(array $rowsData): Entry
+    {
+        $gridData = array_map(function (array $fieldData) {
+            return ['id' => uniqid()] + $fieldData;
+        }, $rowsData);
+
+        $entry = EntryFacade::make()
+            ->collection('pages')
+            ->blueprint('page')
+            ->slug('test-page-grid-multi-'.time().'-'.uniqid())
+            ->data([
+                'title' => 'Test Page with Multiple Grid Rows',
+                'grid_field' => $gridData,
+            ]);
+
+        $entry->save();
+
+        return $entry;
+    }
+
+    /**
+     * Create an entry with asset data in multiple bard set nodes.
+     *
+     * @param  array<int, array<string, mixed>>  $nodesData
+     */
+    protected function createEntryWithBardSetNodes(array $nodesData): Entry
+    {
+        $bardData = array_map(function (array $fieldData) {
+            return [
+                'type' => 'set',
+                'attrs' => [
+                    'id' => uniqid(),
+                    'values' => ['type' => 'media_set'] + $fieldData,
+                ],
+            ];
+        }, $nodesData);
+
+        $entry = EntryFacade::make()
+            ->collection('pages')
+            ->blueprint('page')
+            ->slug('test-page-bard-set-multi-'.time().'-'.uniqid())
+            ->data([
+                'title' => 'Test Page with Multiple Bard Set Nodes',
+                'bard_set_field' => $bardData,
+            ]);
+
+        $entry->save();
+
+        return $entry;
+    }
+
+    /**
      * Create a test asset with specified filename and container
      */
     protected function createAsset(string $filename = 'test-image.jpg', string $container = 'assets'): Asset

--- a/tests/Concerns/CreatesTestEntries.php
+++ b/tests/Concerns/CreatesTestEntries.php
@@ -60,6 +60,60 @@ trait CreatesTestEntries
     }
 
     /**
+     * Create an entry with asset data in a grid row
+     */
+    protected function createEntryWithGridAsset(string $fieldName, mixed $fieldData): Entry
+    {
+        $entry = EntryFacade::make()
+            ->collection('pages')
+            ->blueprint('page')
+            ->slug('test-page-grid-'.time())
+            ->data([
+                'title' => 'Test Page with Grid Asset',
+                'grid_field' => [
+                    [
+                        'id' => uniqid(),
+                        $fieldName => $fieldData,
+                    ],
+                ],
+            ]);
+
+        $entry->save();
+
+        return $entry;
+    }
+
+    /**
+     * Create an entry with asset data inside a bard set node
+     */
+    protected function createEntryWithBardSetAsset(string $fieldName, mixed $fieldData): Entry
+    {
+        $entry = EntryFacade::make()
+            ->collection('pages')
+            ->blueprint('page')
+            ->slug('test-page-bard-set-'.time())
+            ->data([
+                'title' => 'Test Page with Bard Set Asset',
+                'bard_set_field' => [
+                    [
+                        'type' => 'set',
+                        'attrs' => [
+                            'id' => uniqid(),
+                            'values' => [
+                                'type' => 'media_set',
+                                $fieldName => $fieldData,
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+
+        $entry->save();
+
+        return $entry;
+    }
+
+    /**
      * Create a test asset with specified filename and container
      */
     protected function createAsset(string $filename = 'test-image.jpg', string $container = 'assets'): Asset

--- a/tests/Concerns/CreatesTestItems.php
+++ b/tests/Concerns/CreatesTestItems.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Concerns;
+
+use Statamic\Facades\Blueprint;
+use Statamic\Facades\GlobalSet;
+use Statamic\Facades\Site;
+use Statamic\Facades\Taxonomy;
+use Statamic\Facades\Term;
+
+/**
+ * Builds a saved item of each tracked type (entry, term, global) carrying an
+ * asset in a top-level `assets_field`, so a single Pest dataset can exercise
+ * every branch of the TrackAssetReferences subscriber and the scanner's
+ * data-swap across all item types — not just entries.
+ */
+trait CreatesTestItems
+{
+    /**
+     * @param  'entry'|'term'|'global'  $type
+     * @param  array<int, string>  $paths
+     */
+    protected function makeItemWithAsset(string $type, array $paths)
+    {
+        return match ($type) {
+            'entry' => $this->createEntryWithTopLevelAsset('assets_field', $paths),
+            'term' => $this->makeTermWithAsset($paths),
+            'global' => $this->makeGlobalWithAsset($paths),
+        };
+    }
+
+    protected function makeTermWithAsset(array $paths)
+    {
+        $this->ensureTaxonomy();
+
+        $term = Term::make()
+            ->slug('topic-'.uniqid())
+            ->taxonomy('topics');
+
+        $term->dataForLocale(Site::default()->handle(), [
+            'title' => 'Test Topic',
+            'assets_field' => $paths,
+        ]);
+
+        $term->save();
+
+        return $term;
+    }
+
+    protected function makeGlobalWithAsset(array $paths)
+    {
+        $this->ensureGlobalSet();
+
+        $variables = GlobalSet::find('settings')->in(Site::default()->handle());
+        $variables->set('assets_field', $paths);
+        $variables->save();
+
+        return $variables;
+    }
+
+    protected function ensureTaxonomy(): void
+    {
+        if (Taxonomy::findByHandle('topics')) {
+            return;
+        }
+
+        Blueprint::make('topic')
+            ->setNamespace('taxonomies.topics')
+            ->setContents($this->assetsFieldBlueprint())
+            ->save();
+
+        Taxonomy::make('topics')->title('Topics')->save();
+    }
+
+    protected function ensureGlobalSet(): void
+    {
+        if (GlobalSet::find('settings')) {
+            return;
+        }
+
+        Blueprint::make('settings')
+            ->setNamespace('globals')
+            ->setContents($this->assetsFieldBlueprint())
+            ->save();
+
+        $set = GlobalSet::make('settings')->title('Settings');
+        $set->addLocalization($set->makeLocalization(Site::default()->handle()));
+        $set->save();
+    }
+
+    private function assetsFieldBlueprint(): array
+    {
+        return [
+            'tabs' => [
+                'main' => [
+                    'sections' => [
+                        [
+                            'fields' => [
+                                [
+                                    'handle' => 'assets_field',
+                                    'field' => ['type' => 'assets', 'container' => 'assets'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Feature/AssetTracking/ItemTypes/ItemTypeTrackingTest.php
+++ b/tests/Feature/AssetTracking/ItemTypes/ItemTypeTrackingTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use VV\AssetAtlas\AssetScanner;
+
+/*
+ * Cross-type coverage for the TrackAssetReferences subscriber and the scanner's
+ * data-swap. The Nested/* suite proves the swap logic in depth, but only for
+ * entries. These tests run the same paths for terms and global variables - the
+ * other item types the subscriber and scanner handle - via one Pest dataset.
+ *
+ * Top-level assets are enough: the point is to confirm each item type round-
+ * trips through the subscriber (save tracks, delete prunes) and survives the
+ * scanner's swap of $item->data() without corruption.
+ */
+dataset('item types', ['entry', 'term', 'global']);
+
+it('tracks a top-level asset reference when an item is saved', function (string $type) {
+    $asset = $this->createAsset("track-{$type}.jpg");
+
+    $item = $this->makeItemWithAsset($type, [$asset->path()]);
+
+    expect($item)->toBeTrackedFor($asset);
+})->with('item types');
+
+it('restores the item data after a scan (data-swap invariant)', function (string $type) {
+    $asset = $this->createAsset("restore-{$type}.jpg");
+
+    $item = $this->makeItemWithAsset($type, [$asset->path()]);
+    $before = $item->data()->all();
+
+    AssetScanner::item($item)
+        ->checkOriginal()
+        ->addReferences();
+
+    expect($item->data()->all())->toBe($before);
+})->with('item types');

--- a/tests/Feature/AssetTracking/Nested/BardSetReferenceCleanupTest.php
+++ b/tests/Feature/AssetTracking/Nested/BardSetReferenceCleanupTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use VV\AssetAtlas\AssetScanner;
+
+// See ReplicatorReferenceCleanupTest for why pruning is driven via
+// setOriginal()/checkOriginal() rather than through a real save.
+it('prunes a bard set asset reference that was removed from a node', function () {
+    $asset = $this->createAsset('test-bard-set-cleanup.jpg');
+
+    $entry = $this->createEntryWithBardSetAsset('assets_field', [$asset->path()]);
+    expect($entry)->toBeTrackedFor($asset);
+
+    $originalData = $entry->data()->all();
+
+    // The editor deletes the bard set node holding the asset.
+    $entry->set('bard_set_field', []);
+
+    AssetScanner::item($entry)
+        ->setOriginal($originalData)
+        ->checkOriginal()
+        ->addReferences();
+
+    $remaining = DB::table('asset_atlas')
+        ->where('asset_path', $asset->path())
+        ->where('item_id', $entry->id())
+        ->count();
+
+    expect($remaining)->toBe(0,
+        "Stale reference left behind: '{$asset->path()}' is still tracked for entry '{$entry->id()}' after its bard set node was removed."
+    );
+});

--- a/tests/Feature/AssetTracking/Nested/BardSetReferenceCleanupTest.php
+++ b/tests/Feature/AssetTracking/Nested/BardSetReferenceCleanupTest.php
@@ -30,3 +30,42 @@ it('prunes a bard set asset reference that was removed from a node', function ()
         "Stale reference left behind: '{$asset->path()}' is still tracked for entry '{$entry->id()}' after its bard set node was removed."
     );
 });
+
+/*
+ * Partial removal: only one of several bard set nodes is deleted. The removed
+ * node's asset must be pruned while the surviving node's asset must stay tracked.
+ */
+it('prunes only the removed bard set node and keeps the surviving node reference', function () {
+    $removedAsset = $this->createAsset('test-bard-set-removed.jpg');
+    $keptAsset = $this->createAsset('test-bard-set-kept.jpg');
+
+    $entry = $this->createEntryWithBardSetNodes([
+        ['assets_field' => [$removedAsset->path()]],
+        ['assets_field' => [$keptAsset->path()]],
+    ]);
+
+    expect($entry)->toBeTrackedFor($removedAsset)
+        ->toBeTrackedFor($keptAsset);
+
+    $originalData = $entry->data()->all();
+
+    $nodes = $entry->get('bard_set_field');
+    array_shift($nodes);
+    $entry->set('bard_set_field', $nodes);
+
+    AssetScanner::item($entry)
+        ->setOriginal($originalData)
+        ->checkOriginal()
+        ->addReferences();
+
+    expect($entry)->toBeTrackedFor($keptAsset);
+
+    $removedRemaining = DB::table('asset_atlas')
+        ->where('asset_path', $removedAsset->path())
+        ->where('item_id', $entry->id())
+        ->count();
+
+    expect($removedRemaining)->toBe(0,
+        "Stale reference left behind for removed node's asset '{$removedAsset->path()}'."
+    );
+});

--- a/tests/Feature/AssetTracking/Nested/DataSwapRegressionTest.php
+++ b/tests/Feature/AssetTracking/Nested/DataSwapRegressionTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use VV\AssetAtlas\AssetScanner;
+
+/*
+ * Regression guards for the data-swap implementation of nested reference
+ * pruning. The scanner aligns $this->item->data() with the snapshot being
+ * scanned so the inherited DataReferenceUpdater traversal visits the right
+ * sets, then restores the item's data in a finally block. These tests lock in
+ * the two invariants that make that safe:
+ *
+ *   1. The item's data is byte-for-byte restored after a scan - for both the
+ *      current-data pass and the original-data prune pass. A missing restore
+ *      (or a future Statamic change that mutates the item mid-traversal) would
+ *      leak the scanned snapshot onto the live item and is caught here.
+ *
+ *   2. The production entry path - which relies on $item->getOriginal() rather
+ *      than an explicitly setOriginal() snapshot - actually prunes a removed
+ *      nested set's reference. This closes the gap that the per-container
+ *      cleanup tests leave open by driving pruning via setOriginal().
+ */
+
+it('restores the item data after scanning current replicator data', function () {
+    $asset = $this->createAsset('test-restore-replicator.jpg');
+
+    $entry = $this->createEntryWithNestedAsset('assets_field', [$asset->path()]);
+    $before = $entry->data()->all();
+
+    AssetScanner::item($entry)->addReferences();
+
+    expect($entry->data()->all())->toBe($before);
+});
+
+it('restores the item data after scanning current grid data', function () {
+    $asset = $this->createAsset('test-restore-grid.jpg');
+
+    $entry = $this->createEntryWithGridAsset('assets_field', [$asset->path()]);
+    $before = $entry->data()->all();
+
+    AssetScanner::item($entry)->addReferences();
+
+    expect($entry->data()->all())->toBe($before);
+});
+
+it('restores the item data after scanning current bard set data', function () {
+    $asset = $this->createAsset('test-restore-bard.jpg');
+
+    $entry = $this->createEntryWithBardSetAsset('assets_field', [$asset->path()]);
+    $before = $entry->data()->all();
+
+    AssetScanner::item($entry)->addReferences();
+
+    expect($entry->data()->all())->toBe($before);
+});
+
+it('restores the item data after the original-data prune pass', function () {
+    $asset = $this->createAsset('test-restore-original.jpg');
+
+    $entry = $this->createEntryWithNestedAsset('assets_field', [$asset->path()]);
+    $originalData = $entry->data()->all();
+
+    // Mutate current data; the prune pass scans the original snapshot, which
+    // must not leak back onto the live item.
+    $entry->set('replicator_field', []);
+    $currentData = $entry->data()->all();
+
+    AssetScanner::item($entry)
+        ->setOriginal($originalData)
+        ->checkOriginal()
+        ->addReferences();
+
+    expect($entry->data()->all())->toBe($currentData);
+});
+
+/*
+ * Production entry path: Entry::save() syncs the original state, so when the
+ * save subscriber runs AssetScanner::item($entry)->checkOriginal()->addReferences()
+ * without setOriginal(), getOriginal() falls back to the synced snapshot. This
+ * proves that path carries nested set data in a shape the traversal can walk.
+ */
+it('prunes a removed replicator set reference via the getOriginal fallback', function () {
+    $asset = $this->createAsset('test-getoriginal-fallback.jpg');
+
+    // Saving syncs the original state to include the nested asset reference.
+    $entry = $this->createEntryWithNestedAsset('assets_field', [$asset->path()]);
+    expect($entry)->toBeTrackedFor($asset);
+
+    // Sanity: getOriginal() reflects the saved nested structure.
+    expect($entry->getOriginal('replicator_field'))->not->toBeEmpty();
+
+    // Editor deletes the set; current data no longer references the asset.
+    $entry->set('replicator_field', []);
+
+    // No setOriginal() here - this is the real entry save subscriber call.
+    AssetScanner::item($entry)
+        ->checkOriginal()
+        ->addReferences();
+
+    $remaining = DB::table('asset_atlas')
+        ->where('asset_path', $asset->path())
+        ->where('item_id', $entry->id())
+        ->count();
+
+    expect($remaining)->toBe(0,
+        "Stale reference left behind when pruning relied on getOriginal(): '{$asset->path()}' still tracked for entry '{$entry->id()}'."
+    );
+});

--- a/tests/Feature/AssetTracking/Nested/GridReferenceCleanupTest.php
+++ b/tests/Feature/AssetTracking/Nested/GridReferenceCleanupTest.php
@@ -30,3 +30,43 @@ it('prunes a grid asset reference that was removed from a row', function () {
         "Stale reference left behind: '{$asset->path()}' is still tracked for entry '{$entry->id()}' after its grid row was removed."
     );
 });
+
+/*
+ * Partial removal: only one of several grid rows is deleted. The removed row's
+ * asset must be pruned while the surviving row's asset must stay tracked.
+ */
+it('prunes only the removed grid row and keeps the surviving row reference', function () {
+    $removedAsset = $this->createAsset('test-grid-removed.jpg');
+    $keptAsset = $this->createAsset('test-grid-kept.jpg');
+
+    $entry = $this->createEntryWithGridRows([
+        ['assets_field' => [$removedAsset->path()]],
+        ['assets_field' => [$keptAsset->path()]],
+    ]);
+
+    expect($entry)
+        ->toBeTrackedFor($removedAsset)
+        ->toBeTrackedFor($keptAsset);
+
+    $originalData = $entry->data()->all();
+
+    $rows = $entry->get('grid_field');
+    array_shift($rows);
+    $entry->set('grid_field', $rows);
+
+    AssetScanner::item($entry)
+        ->setOriginal($originalData)
+        ->checkOriginal()
+        ->addReferences();
+
+    expect($entry)->toBeTrackedFor($keptAsset);
+
+    $removedRemaining = DB::table('asset_atlas')
+        ->where('asset_path', $removedAsset->path())
+        ->where('item_id', $entry->id())
+        ->count();
+
+    expect($removedRemaining)->toBe(0,
+        "Stale reference left behind for removed row's asset '{$removedAsset->path()}'."
+    );
+});

--- a/tests/Feature/AssetTracking/Nested/GridReferenceCleanupTest.php
+++ b/tests/Feature/AssetTracking/Nested/GridReferenceCleanupTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use VV\AssetAtlas\AssetScanner;
+
+// See ReplicatorReferenceCleanupTest for why pruning is driven via
+// setOriginal()/checkOriginal() rather than through a real save.
+it('prunes a grid asset reference that was removed from a row', function () {
+    $asset = $this->createAsset('test-grid-cleanup.jpg');
+
+    $entry = $this->createEntryWithGridAsset('assets_field', [$asset->path()]);
+    expect($entry)->toBeTrackedFor($asset);
+
+    $originalData = $entry->data()->all();
+
+    // The editor deletes the grid row holding the asset.
+    $entry->set('grid_field', []);
+
+    AssetScanner::item($entry)
+        ->setOriginal($originalData)
+        ->checkOriginal()
+        ->addReferences();
+
+    $remaining = DB::table('asset_atlas')
+        ->where('asset_path', $asset->path())
+        ->where('item_id', $entry->id())
+        ->count();
+
+    expect($remaining)->toBe(0,
+        "Stale reference left behind: '{$asset->path()}' is still tracked for entry '{$entry->id()}' after its grid row was removed."
+    );
+});

--- a/tests/Feature/AssetTracking/Nested/ReplicatorReferenceCleanupTest.php
+++ b/tests/Feature/AssetTracking/Nested/ReplicatorReferenceCleanupTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use VV\AssetAtlas\AssetScanner;
+
+/*
+ * Regression test for stale references left inside replicator/grid/bard sets.
+ *
+ * When an item is saved, the scanner re-scans its *original* data and prunes
+ * references that no longer exist in the current data. That pruning is exercised
+ * directly here via setOriginal()/checkOriginal() - the same API the GlobalVars
+ * subscriber uses - rather than through a real save. The testbench harness syncs
+ * an entry's original state *before* EntrySaved fires (real Statamic syncs it
+ * after), so an event-driven test cannot observe the original data the pruning
+ * relies on.
+ */
+it('prunes a nested replicator asset reference that was removed from a set', function () {
+    $asset = $this->createAsset('test-replicator-cleanup.jpg');
+
+    // Entry that once held the asset inside a replicator set -> reference tracked.
+    $entry = $this->createEntryWithNestedAsset('assets_field', [$asset->path()]);
+    expect($entry)->toBeTrackedFor($asset);
+
+    $originalData = $entry->data()->all();
+
+    // The editor deletes the set; the current data no longer references the asset.
+    $entry->set('replicator_field', []);
+
+    // Same call the save subscriber makes: scan current data, then diff against
+    // the original to drop references that disappeared.
+    AssetScanner::item($entry)
+        ->setOriginal($originalData)
+        ->checkOriginal()
+        ->addReferences();
+
+    $remaining = DB::table('asset_atlas')
+        ->where('asset_path', $asset->path())
+        ->where('item_id', $entry->id())
+        ->count();
+
+    expect($remaining)->toBe(0,
+        "Stale reference left behind: '{$asset->path()}' is still tracked for entry '{$entry->id()}' after its replicator set was removed."
+    );
+});

--- a/tests/Feature/AssetTracking/Nested/ReplicatorReferenceCleanupTest.php
+++ b/tests/Feature/AssetTracking/Nested/ReplicatorReferenceCleanupTest.php
@@ -7,12 +7,16 @@ use VV\AssetAtlas\AssetScanner;
  * Regression test for stale references left inside replicator/grid/bard sets.
  *
  * When an item is saved, the scanner re-scans its *original* data and prunes
- * references that no longer exist in the current data. That pruning is exercised
- * directly here via setOriginal()/checkOriginal() - the same API the GlobalVars
- * subscriber uses - rather than through a real save. The testbench harness syncs
- * an entry's original state *before* EntrySaved fires (real Statamic syncs it
- * after), so an event-driven test cannot observe the original data the pruning
- * relies on.
+ * references that no longer exist in the current data. In real Statamic,
+ * Entry::save() dispatches EntrySaved *before* calling syncOriginal()
+ * (Entry.php:433 then :446), so during the save subscriber getOriginal()
+ * returns the previous save's snapshot - the pre-edit data the prune pass diffs
+ * against. That fallback is proven by DataSwapRegressionTest.
+ *
+ * Here we drive the prune pass directly via setOriginal()/checkOriginal() - the
+ * same API the GlobalVars subscriber uses - rather than through a second real
+ * save. This isolates the nested-prune logic from the two-save dance and the
+ * subscriber/transaction/Stache wiring, and lets us feed an exact snapshot.
  */
 it('prunes a nested replicator asset reference that was removed from a set', function () {
     $asset = $this->createAsset('test-replicator-cleanup.jpg');

--- a/tests/Feature/AssetTracking/Nested/ReplicatorReferenceCleanupTest.php
+++ b/tests/Feature/AssetTracking/Nested/ReplicatorReferenceCleanupTest.php
@@ -42,3 +42,46 @@ it('prunes a nested replicator asset reference that was removed from a set', fun
         "Stale reference left behind: '{$asset->path()}' is still tracked for entry '{$entry->id()}' after its replicator set was removed."
     );
 });
+
+/*
+ * Partial removal: only one of several replicator sets is deleted. The removed
+ * set's asset must be pruned while the surviving set's asset must stay tracked.
+ * Guards against over-pruning and against a broken nested traversal that would
+ * skip surviving sets.
+ */
+it('prunes only the removed replicator set and keeps the surviving set reference', function () {
+    $removedAsset = $this->createAsset('test-replicator-removed.jpg');
+    $keptAsset = $this->createAsset('test-replicator-kept.jpg');
+
+    $entry = $this->createEntryWithReplicatorSets([
+        ['assets_field' => [$removedAsset->path()]],
+        ['assets_field' => [$keptAsset->path()]],
+    ]);
+
+    expect($entry)
+        ->toBeTrackedFor($removedAsset)
+        ->toBeTrackedFor($keptAsset);
+
+    $originalData = $entry->data()->all();
+
+    // Drop the first set; keep the second set verbatim.
+    $sets = $entry->get('replicator_field');
+    array_shift($sets);
+    $entry->set('replicator_field', $sets);
+
+    AssetScanner::item($entry)
+        ->setOriginal($originalData)
+        ->checkOriginal()
+        ->addReferences();
+
+    expect($entry)->toBeTrackedFor($keptAsset);
+
+    $removedRemaining = DB::table('asset_atlas')
+        ->where('asset_path', $removedAsset->path())
+        ->where('item_id', $entry->id())
+        ->count();
+
+    expect($removedRemaining)->toBe(0,
+        "Stale reference left behind for removed set's asset '{$removedAsset->path()}'."
+    );
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,12 +5,14 @@ namespace Tests;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Statamic\Testing\AddonTestCase;
 use Tests\Concerns\CreatesTestEntries;
+use Tests\Concerns\CreatesTestItems;
 use Tests\Concerns\UsesTestFixtures;
 use VV\AssetAtlas\ServiceProvider;
 
 abstract class TestCase extends AddonTestCase
 {
     use CreatesTestEntries;
+    use CreatesTestItems;
     use RefreshDatabase;
     use UsesTestFixtures;
 

--- a/tests/fixtures/blueprints/collections/pages/page.yaml
+++ b/tests/fixtures/blueprints/collections/pages/page.yaml
@@ -52,6 +52,37 @@ tabs:
               display: 'Link Field'
               container: assets
           -
+            handle: grid_field
+            field:
+              type: grid
+              display: 'Grid Field'
+              fields:
+                -
+                  handle: assets_field
+                  field:
+                    container: assets
+                    type: assets
+                    display: 'Assets Field'
+          -
+            handle: bard_set_field
+            field:
+              type: bard
+              display: 'Bard Field with Sets'
+              remove_empty_nodes: false
+              sets:
+                set_group:
+                  display: 'Set Group'
+                  sets:
+                    media_set:
+                      display: 'Media Set'
+                      fields:
+                        -
+                          handle: assets_field
+                          field:
+                            container: assets
+                            type: assets
+                            display: 'Assets Field'
+          -
             handle: replicator_field
             field:
               type: replicator


### PR DESCRIPTION
Asset references used **inside a replicator, grid or bard set** were never removed when that set was deleted. The asset stayed flagged "in use" forever, so editors could not delete it.

**Cause.** On save, the scanner re-scans an item's *original* data to prune references that disappeared. The nested-container traversal is inherited from Statamic's `DataReferenceUpdater`, which reads the set structure from the *live* item (`$this->item->data()`) instead of the snapshot being scanned (`$this->dataToScan`). So the original pass walked the *current* sets, never visited the removed set, and left its references orphaned. Top-level fields were unaffected.

**Fix.** Override `updateReplicatorChildren` / `updateGridChildren` / `updateBardChildren` to iterate `$this->dataToScan`. Each mirrors its parent verbatim except for the data source.

**Tests.** One regression test per container type — each fails without the fix, passes with it. Full suite green, pint clean.

**Note.** This only stops *new* drift. References that already went stale need a one-off `statamic:asset-atlas:scan --reset --force`.
