### PR TITLE
fix: scan from a snapshot instead of mutating the scanned item

### DIFF
--- a/src/AssetScanner.php
+++ b/src/AssetScanner.php
@@ -5,6 +5,7 @@ namespace VV\AssetAtlas;
 use Illuminate\Support\Arr;
 use Statamic\Data\DataReferenceUpdater;
 use Statamic\Facades\AssetContainer;
+use Statamic\Fields\Fields;
 use VV\AssetAtlas\Concerns\GetsItemMetaData;
 
 class AssetScanner extends DataReferenceUpdater
@@ -92,24 +93,7 @@ class AssetScanner extends DataReferenceUpdater
     {
         $this->atlasItems = collect([]);
         $this->dataToScan = $source ?? $this->item->data()->all();
-
-        // The nested-children traversal inherited from DataReferenceUpdater reads
-        // the set/row structure straight from $this->item->data(), not from the
-        // snapshot in $this->dataToScan. So that the inherited replicator/grid/
-        // bard/group traversals visit the same sets the leaf scanners do - in
-        // particular the *original* data when pruning stale references - align the
-        // item's data with the snapshot for the duration of the scan, then restore.
-        // data() is a pure property setter (ContainsData) and the scan path never
-        // saves the item, so this swap has no persistence side effects.
-        $previousData = $this->item->data()->all();
-
-        $this->item->data($this->dataToScan);
-
-        try {
-            $this->recursivelyUpdateFields($this->getTopLevelFields());
-        } finally {
-            $this->item->data($previousData);
-        }
+        $this->recursivelyUpdateFields($this->getTopLevelFields());
     }
 
     protected function push(string $container, string $path)
@@ -127,6 +111,49 @@ class AssetScanner extends DataReferenceUpdater
             ->scanBardFieldValues($fields, $dottedPrefix)
             ->scanMarkdownFieldValues($fields, $dottedPrefix)
             ->updateNestedFieldValues($fields, $dottedPrefix);
+    }
+
+    /*
+     * The nested-children traversal inherited from DataReferenceUpdater reads the
+     * set/row structure straight from the live item ($this->item->data()). The
+     * scanner instead has to honour $this->dataToScan, because when we re-scan the
+     * *original* data to prune stale references we pass that snapshot in as the
+     * source. Without these overrides the original pass would iterate the *current*
+     * set structure, never visit sets that were removed, and leave their asset
+     * references orphaned in the atlas. Each override mirrors its parent verbatim
+     * except for the data source.
+     */
+    protected function updateReplicatorChildren($field, $dottedKey)
+    {
+        collect(Arr::get($this->dataToScan, $dottedKey))->each(function ($set, $setKey) use ($dottedKey, $field) {
+            $setHandle = Arr::get($set, 'type');
+            $fields = Arr::get($field->fieldtype()->flattenedSetsConfig(), "{$setHandle}.fields");
+
+            if ($setHandle && $fields) {
+                $this->recursivelyUpdateFields((new Fields($fields))->all(), "{$dottedKey}.{$setKey}.");
+            }
+        });
+    }
+
+    protected function updateGridChildren($field, $dottedKey)
+    {
+        collect(Arr::get($this->dataToScan, $dottedKey))->each(function ($set, $setKey) use ($dottedKey, $field) {
+            if ($fields = Arr::get($field->config(), 'fields')) {
+                $this->recursivelyUpdateFields((new Fields($fields))->all(), "{$dottedKey}.{$setKey}.");
+            }
+        });
+    }
+
+    protected function updateBardChildren($field, $dottedKey)
+    {
+        collect(Arr::get($this->dataToScan, $dottedKey))->each(function ($set, $setKey) use ($dottedKey, $field) {
+            $setHandle = Arr::get($set, 'attrs.values.type');
+            $fields = Arr::get($field->fieldtype()->flattenedSetsConfig(), "{$setHandle}.fields");
+
+            if ($setHandle && $fields) {
+                $this->recursivelyUpdateFields((new Fields($fields))->all(), "{$dottedKey}.{$setKey}.attrs.values.");
+            }
+        });
     }
 
     protected function getConfiguredAssetsFieldContainer($field)

--- a/tests/Concerns/CreatesTestItems.php
+++ b/tests/Concerns/CreatesTestItems.php
@@ -11,8 +11,8 @@ use Statamic\Facades\Term;
 /**
  * Builds a saved item of each tracked type (entry, term, global) carrying an
  * asset in a top-level `assets_field`, so a single Pest dataset can exercise
- * every branch of the TrackAssetReferences subscriber and the scanner's
- * data-swap across all item types — not just entries.
+ * every branch of the TrackAssetReferences subscriber and the scanner
+ * across all item types — not just entries.
  */
 trait CreatesTestItems
 {

--- a/tests/Feature/AssetTracking/ItemTypes/ItemTypeTrackingTest.php
+++ b/tests/Feature/AssetTracking/ItemTypes/ItemTypeTrackingTest.php
@@ -3,14 +3,14 @@
 use VV\AssetAtlas\AssetScanner;
 
 /*
- * Cross-type coverage for the TrackAssetReferences subscriber and the scanner's
- * data-swap. The Nested/* suite proves the swap logic in depth, but only for
- * entries. These tests run the same paths for terms and global variables - the
- * other item types the subscriber and scanner handle - via one Pest dataset.
+ * Cross-type coverage for the TrackAssetReferences subscriber and the scanner.
+ * The Nested/* suite proves the traversal in depth, but only for entries. These
+ * tests run the same paths for terms and global variables - the other item
+ * types the subscriber and scanner handle - via one Pest dataset.
  *
  * Top-level assets are enough: the point is to confirm each item type round-
- * trips through the subscriber (save tracks, delete prunes) and survives the
- * scanner's swap of $item->data() without corruption.
+ * trips through the subscriber (save tracks, delete prunes) and is left
+ * untouched by the scan.
  */
 dataset('item types', ['entry', 'term', 'global']);
 
@@ -22,7 +22,7 @@ it('tracks a top-level asset reference when an item is saved', function (string 
     expect($item)->toBeTrackedFor($asset);
 })->with('item types');
 
-it('restores the item data after a scan (data-swap invariant)', function (string $type) {
+it('leaves the item data untouched after a scan', function (string $type) {
     $asset = $this->createAsset("restore-{$type}.jpg");
 
     $item = $this->makeItemWithAsset($type, [$asset->path()]);

--- a/tests/Feature/AssetTracking/Nested/NestedPruningIntegrityTest.php
+++ b/tests/Feature/AssetTracking/Nested/NestedPruningIntegrityTest.php
@@ -4,16 +4,14 @@ use Illuminate\Support\Facades\DB;
 use VV\AssetAtlas\AssetScanner;
 
 /*
- * Regression guards for the data-swap implementation of nested reference
- * pruning. The scanner aligns $this->item->data() with the snapshot being
- * scanned so the inherited DataReferenceUpdater traversal visits the right
- * sets, then restores the item's data in a finally block. These tests lock in
- * the two invariants that make that safe:
+ * Integrity guards for nested reference pruning. The scanner reads set/row
+ * structure from its own $dataToScan snapshot (via the *Children overrides)
+ * rather than mutating the live item, so these tests lock in two invariants:
  *
- *   1. The item's data is byte-for-byte restored after a scan - for both the
- *      current-data pass and the original-data prune pass. A missing restore
- *      (or a future Statamic change that mutates the item mid-traversal) would
- *      leak the scanned snapshot onto the live item and is caught here.
+ *   1. The item's data is byte-for-byte unchanged after a scan - for both the
+ *      current-data pass and the original-data prune pass. The scanner must
+ *      never write back to the item it scans (see ScannerDoesNotMutateItemTest
+ *      for the contract-level guard); a regression here would mean it did.
  *
  *   2. The production entry path - which relies on $item->getOriginal() rather
  *      than an explicitly setOriginal() snapshot - actually prunes a removed

--- a/tests/Feature/AssetTracking/ScannerDoesNotMutateItemTest.php
+++ b/tests/Feature/AssetTracking/ScannerDoesNotMutateItemTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Statamic\Facades\Blueprint;
+use VV\AssetAtlas\AssetScanner;
+
+/*
+ * Contract: the scanner must never write back to the item it scans.
+ *
+ * v0.6.0 briefly aligned $item->data() with the scanned snapshot and restored
+ * it in a finally block, on the assumption that data() is a side-effect-free
+ * property bag. That assumption is false for items with an asymmetric data()
+ * accessor - most importantly Statamic's Eloquent User, whose getter injects
+ * computed `roles`/`groups` keys that the setter then materialises as model
+ * attributes. The next save of that user then emits `update users set ...,
+ * roles = [], groups = []`, crashing on installs whose users table has no such
+ * columns (and silently wiping roles on installs that do).
+ *
+ * This pins the invariant with a minimal asymmetric item so a future change
+ * cannot reintroduce the write-back. The scanner reads nested structure from
+ * its own $dataToScan snapshot (see AssetScanner's *Children overrides), never
+ * by mutating the live item.
+ */
+
+it('never writes back to the scanned item', function () {
+    $item = new class
+    {
+        public int $setterCalls = 0;
+
+        public function id()
+        {
+            return 'spy-item';
+        }
+
+        public function blueprint()
+        {
+            return Blueprint::makeFromFields([
+                'assets_field' => ['type' => 'assets', 'container' => 'assets'],
+            ]);
+        }
+
+        public function data($data = null)
+        {
+            if (func_num_args() === 0) {
+                // Asymmetric getter: injects a computed key the setter would
+                // persist, mirroring Eloquent User::data() adding roles/groups.
+                return collect([
+                    'assets_field' => ['spy/image.jpg'],
+                    'computed_key' => 'value',
+                ]);
+            }
+
+            $this->setterCalls++;
+
+            return $this;
+        }
+    };
+
+    AssetScanner::item($item)->removeReferences();
+
+    expect($item->setterCalls)->toBe(0);
+});


### PR DESCRIPTION
## What

Revert the v0.6.0 "data-swap" back to snapshot-reading traversal overrides, so the scanner never writes back to the item it scans.

## Why

To make the inherited `DataReferenceUpdater` traversal visit the right sets, v0.6.0 temporarily overwrote `$item->data()` with the scanned snapshot and restored it in a `finally` block, with the comment:

> data() is a pure property setter (ContainsData) and the scan path never saves the item, so this swap has no persistence side effects.

That assumption is false for items with an **asymmetric `data()` accessor**. Statamic's Eloquent `User` (`Statamic\Auth\Eloquent\User`) getter injects computed `roles`/`groups`:

```php
public function data($data = null) {
    if (func_num_args() === 0) {
        return collect(Arr::except(array_merge($this->model()->attributesToArray(), [
            'roles'  => $this->roles()->map->handle()->values()->all(),
            'groups' => $this->groups()->map->handle()->values()->all(),
        ]), ['id', 'email']));
    }
    foreach ($data as $key => $value) { $this->set($key, $value); } // materialises roles/groups as model attributes
}
```

On `UserSaved` the scanner round-trips `data()`, dirtying `roles`/`groups` on the model. The **next** save of that user emits:

```
update users set ..., roles = [], groups = []
```

- Installs whose `users` table has no `roles`/`groups` columns (e.g. roles/groups stored via separate tables) → **hard crash** (`no such column: roles`).
- Installs that do have them → **silently wipes the user's roles**.

Found via a downstream app whose CMS test suite went red on the 0.5 → 0.6 bump (`update users set ... "roles" = [] ... no such column: roles`), and which stores roles/groups outside the users table in production too — so this is not test-only.

## Fix

- Restore the three snapshot-reading overrides (`updateReplicatorChildren`/`updateGridChildren`/`updateBardChildren`) that read from `$this->dataToScan`, and drop the swap. The scanner no longer touches the live item.
- No `updateGroupChildren` override needed: the parent reads `$this->item->data()` into a variable it never uses (group subfields come from static blueprint config), so there is nothing data-dependent to snapshot.

## Tests

- **New** `ScannerDoesNotMutateItemTest` — pins the contract with a minimal asymmetric item (computed key in the getter). Verified it **fails against the old swap** and passes with this fix.
- Reworded the swap-era docs; renamed `DataSwapRegressionTest` → `NestedPruningIntegrityTest` (its invariants still hold and now assert the item is left untouched).
- Full suite green (37 passed) on sqlite, matching CI.

## Notes

- The nested-pruning behaviour v0.6.0 shipped (stale refs inside removed replicator/grid/bard sets) is preserved — the overrides are the earlier implementation from this same line of work, just without the swap.
- After release, a downstream constraint bump to the new patch is all that's needed.
