### PR TITLE
Enforce uniqueness of asset references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+- `CHANGELOG.md` is auto-generated on release by `.github/workflows/update-changelog.yml`. Don't edit it by hand.

--- a/database/migrations/create_asset_atlas_table.php
+++ b/database/migrations/create_asset_atlas_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->string('item_type');
             $table->timestamps();
 
-            $table->index(['asset_path', 'asset_container']);
+            $table->unique(['asset_path', 'asset_container', 'item_id', 'item_type'], 'asset_atlas_unique_reference');
         });
     }
 

--- a/src/Atlas.php
+++ b/src/Atlas.php
@@ -8,6 +8,7 @@ use Statamic\Facades\Entry;
 use Statamic\Facades\GlobalVariables;
 use Statamic\Facades\Term;
 use Statamic\Facades\User;
+use VV\AssetAtlas\Exceptions\AssetAtlasException;
 
 class Atlas
 {

--- a/src/Exceptions/AssetAtlasException.php
+++ b/src/Exceptions/AssetAtlasException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VV\AssetAtlas;
+namespace VV\AssetAtlas\Exceptions;
 
 use Exception;
 

--- a/tests/Feature/UniqueReferenceIndexTest.php
+++ b/tests/Feature/UniqueReferenceIndexTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Ramsey\Uuid\Uuid;
+use VV\AssetAtlas\AssetAtlas;
+use VV\AssetAtlas\AssetReference;
+
+it('stores duplicate asset references only once', function () {
+    $assetPath = 'images/hero.jpg';
+    $assetContainer = 'assets';
+    $itemId = Uuid::uuid4()->toString();
+    $itemType = 'entry';
+
+    AssetAtlas::store($assetPath, $assetContainer, $itemId, $itemType);
+    AssetAtlas::store($assetPath, $assetContainer, $itemId, $itemType);
+
+    $count = AssetReference::query()
+        ->where('asset_path', $assetPath)
+        ->where('asset_container', $assetContainer)
+        ->where('item_id', $itemId)
+        ->where('item_type', $itemType)
+        ->count();
+
+    expect($count)->toBe(1);
+});
+
+it('rejects duplicate asset references at the database level', function () {
+    $reference = [
+        'asset_path' => 'images/hero.jpg',
+        'asset_container' => 'assets',
+        'item_id' => Uuid::uuid4()->toString(),
+        'item_type' => 'entry',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ];
+
+    DB::table('asset_atlas')->insert($reference);
+
+    expect(fn () => DB::table('asset_atlas')->insert($reference))
+        ->toThrow(QueryException::class);
+});


### PR DESCRIPTION
Asset references are de-duplicated only at the app layer via `firstOrCreate()`, with no DB-level guard — so a race or a double-fired event can still persist duplicate rows for the same `(asset_path, asset_container, item_id, item_type)`, which then surface as duplicate entries in linked-entry lookups.

Replaces the non-unique lookup index with a unique index across those four columns. The left prefix still serves the existing path/container lookups, so no separate index is needed.